### PR TITLE
Fix flex

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -16,7 +16,7 @@
 }
 
 .brands__logo {
-    width: 100%;
+    min-width: 0;
     margin: 0 0.5rem;
     align-self: center;
 }


### PR DESCRIPTION
Closes #22 

Firefox and Chrome assign different min-width values to items inside a flex. By explicitly defining a min-width of 0, the images would then resize to fit the flex they are in.